### PR TITLE
Add the __ne__ magic method

### DIFF
--- a/src/genpy/message.py
+++ b/src/genpy/message.py
@@ -365,6 +365,8 @@ class Message(object):
             except AttributeError:
                 return False
         return True
+    def __ne__(self, other):
+        return not self == other
     
 
 def get_printable_message_args(msg, buff=None, prefix=''):

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -455,7 +455,6 @@ class MessageTest(unittest.TestCase):
                 self.fail("check_types for %s should have failed"%m)
             except SerializationError: pass
         
-        
         valid = [
             ((), {}, M1),
             ((), {}, M2),
@@ -486,6 +485,11 @@ class MessageTest(unittest.TestCase):
                 cls(*args, **kwds)
                 self.fail("Message should have failed for cls[%s] *args[%s] and **kwds[%s]"%(cls, args, kwds))
             except: pass
+        
+        # Test inequality of identical messages is False
+        m2_first = M2(a=1, b=2)
+        m2_second = M2(a=1, b=2)
+        self.assertFalse(m2_first != m2_second)
         
     def test_strify_message(self):
         # this is a bit overtuned, but it will catch regressions

--- a/test/test_genpy_message.py
+++ b/test/test_genpy_message.py
@@ -487,9 +487,7 @@ class MessageTest(unittest.TestCase):
             except: pass
         
         # Test inequality of identical messages is False
-        m2_first = M2(a=1, b=2)
-        m2_second = M2(a=1, b=2)
-        self.assertFalse(m2_first != m2_second)
+        self.assertFalse(M2(a=1, b=2) != M2(a=1, b=2))
         
     def test_strify_message(self):
         # this is a bit overtuned, but it will catch regressions


### PR DESCRIPTION
In Python 2, if you do not define a magic method, such as `__eq__`  for equality, or `__ne__` for inequality, it defaults to comparing the object IDs, which are random. That causes checking for inequality (`msg_1 != msg_2`) to work unexpectedly. (i.e., even if the messages are equal, it would return True.) In fact, the [Python 2 docs](https://docs.python.org/2/reference/datamodel.html#basic-customization) say that it is best to add them too.

In Python 3, `__ne__` is simply the inverse of `__eq__` if it is not defined.
